### PR TITLE
MLSS: Remove logging from validate_rom in client

### DIFF
--- a/worlds/mlss/Client.py
+++ b/worlds/mlss/Client.py
@@ -48,10 +48,6 @@ class MLSSClient(BizHawkClient):
             rom_name_bytes = await bizhawk.read(ctx.bizhawk_ctx, [(0xA0, 14, "ROM")])
             rom_name = bytes([byte for byte in rom_name_bytes[0] if byte != 0]).decode("UTF-8")
             if not rom_name.startswith("MARIO&LUIGIUA8"):
-                logger.info(
-                    "ERROR: You have opened a game that is not Mario & Luigi Superstar Saga. "
-                    "Please make sure you are opening the correct ROM."
-                )
                 return False
         except UnicodeDecodeError:
             return False


### PR DESCRIPTION
## What is this fixing or adding?
This removes an unnecessary logger.info() call from validate_rom. It would print to the console for any game loaded into Bizhawk Client that had a name alphabetically after mlss.

## How was this tested?
Loading a game of Pokemon Emerald no longer pops up a logger message from mlss client.

## If this makes graphical changes, please attach screenshots.
